### PR TITLE
*Nix support

### DIFF
--- a/src/sysconfcpus.in
+++ b/src/sysconfcpus.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # libsysconfcpus: adjust number of CPUs reported by sysconf()
 # Copyright (C) 2008-2009 Kevin Pulo


### PR DESCRIPTION
http://stackoverflow.com/questions/10376206/what-is-the-preferred-bash-shebang

(I run NixOS, which doesn't have bash at `/bin/bash`)
